### PR TITLE
Replace "BATTLEGROUND" with "INSTANCE_CHAT"

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -1298,7 +1298,7 @@ end
 local instanceType
 local function updateDistributionChannel()
 	if( instanceType == "pvp" ) then
-		distribution = "BATTLEGROUND"
+		distribution = "INSTANCE_CHAT"
 	elseif( IsInRaid() ) then
 		distribution = "RAID"
 	elseif( IsInGroup() ) then


### PR DESCRIPTION
"BATTLEGROUND" was removed in patch 5.1 and was replaced by "INSTANCE_CHAT".