### PR TITLE
Fix for issue #32

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -698,6 +698,10 @@ end
 
 local function calculateGeneralAmount(level, amount, spellPower, spModifier, healModifier)
 	local penalty = level > 20 and 1 or (1 - ((20 - level) * 0.0375))
+	if isTBC then
+		-- TBC added another downrank penalty
+		penalty = penalty * min(1, (level + 11) / playerLevel)
+	end
 
 	spellPower = spellPower * penalty
 


### PR DESCRIPTION
TBC added a new spell downrank penalty over the existing Lv20 spell penalty.
This fixes issue #32.
I checked in-game with Healing Wave rank 1 -- predicted value with new penalty matches actual heal output.
