### PR TITLE
Added Gift of the Naaru support, fixed Tranquility, fixed heals getting stuck on, fixed AoE spell targetting, added new function

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -1,10 +1,10 @@
 if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then return end
 
-local major = "LibHealComm-4.0-Custom"
-local minor = 93
+local major = "LibHealComm-4.0"
+local minor = 95
 assert(LibStub, format("%s requires LibStub.", major))
 
-HealComm = LibStub:NewLibrary(major, minor)
+local HealComm = LibStub:NewLibrary(major, minor)
 if( not HealComm ) then return end
 
 local COMM_PREFIX = "LHC40"
@@ -82,7 +82,7 @@ local spellRankTableData = {
 	[5] = { 2091, 8941, 5189, 1042, 19942, 6077, 22009, 25314, 25316, 10915, 939, 10467, 13542, 11693, 11699, 7926, 25423, 26983 },
 	[6] = { 3627, 9750, 6778, 3472, 19943, 6078, 10916, 959, 10468, 13543, 11694, 11700, 7927, 23569, 24412, 25210, 25308 },
 	[7] = { 8910, 9856, 8903, 10328, 10927, 10917, 8005, 13544, 11695, 10838, 27137, 25213, 25420, 27219 },
-	[8] = { 9839, 9857, 9758, 10329, 10928, 10395, 10839, 23568, 24413, 25233, 27259, 27220 },
+	[8] = { 9839, 9857, 9758, 10329, 10928, 10395, 10839, 23568, 24413, 25233, 27259, 27220, 27046 },
 	[9] = { 9840, 9858, 9888, 25292, 10929, 10396, 18608, 25235 },
 	[10] = { 9841, 9889, 25315, 25357, 18610, 23567, 24414, 26980, 27135 },
 	[11] = { 25299, 25297, 30020, 27136, 25221, 25391, 27030 },
@@ -812,8 +812,12 @@ end
 
 local CalculateHealing, GetHealTargets, AuraHandler, CalculateHotHealing, ResetChargeData, LoadClassData
 
-local function getBaseHealAmount(spellData, spellName, spellRank)
-	spellData = spellData[spellName]
+local function getBaseHealAmount(spellData, spellName, spellID, spellRank)
+	if spellID == 37563 then
+		spellData = spellData["37563"]
+	else
+		spellData = spellData[spellName]
+	end
 	local average = spellData.averages[spellRank]
 	if type(average) == "number" then
 		return average
@@ -915,7 +919,7 @@ if( playerClass == "DRUID" ) then
 		-- Calculate hot heals
 		CalculateHotHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(hotData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(hotData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 			local bombAmount, totalTicks
@@ -964,27 +968,27 @@ if( playerClass == "DRUID" ) then
 				healAmount = healAmount / hotData[spellName].ticks
 
 				totalTicks = 7
-				
+
 				if( equippedSetCache["Nordrassil"] >= 2 ) then totalTicks = totalTicks + 2 end
-				
+
 			elseif( spellName == Lifebloom ) then
 				-- Figure out the bomb heal, apparently Gift of Nature double dips and will heal 10% for the HOT + 10% again for the direct heal
 				local bombSpellPower = spellPower
 				if( playerCurrentRelic and bloomBombIdols[playerCurrentRelic] ) then
 					bombSpellPower = bombSpellPower + bloomBombIdols[playerCurrentRelic]
 				end
-				
+
 				local bombSpell = bombSpellPower * hotData[spellName].dhCoeff * (1 + talentData[EmpoweredRejuv].current)
 				bombAmount = math.ceil(calculateGeneralAmount(hotData[spellName].levels[spellRank], hotData[spellName].bomb[spellRank], bombSpell, spModifier, healModifier))
-			
+
 				-- Figure out the hot tick healing
 				spellPower = spellPower * (hotData[spellName].coeff * (1 + talentData[EmpoweredRejuv].current))
-				
+
 				-- Idol of the Emerald Queen, +47 SP per tick
 				if( playerCurrentRelic == 27886 ) then
 					spellPower = spellPower + 47
 				end
-				
+
 				spellPower = spellPower / hotData[spellName].ticks
 				healAmount = healAmount / hotData[spellName].ticks
 				-- Figure out total ticks
@@ -999,7 +1003,7 @@ if( playerClass == "DRUID" ) then
 		-- Calcualte direct and channeled heals
 		CalculateHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(spellData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 
@@ -1016,22 +1020,22 @@ if( playerClass == "DRUID" ) then
 				spellPower = spellPower * spellData[spellName].coeff
 			-- Healing Touch
 			elseif( spellName == HealingTouch ) then
-				
+
 				healAmount = healAmount + (spellPower * talentData[EmpoweredTouch].current)
-				
+
 				local castTime = spellRank >= 5 and 3.5 or (spellRank == 4 and 3 or (spellRank == 3 and 2.5 or (spellRank == 2 and 2 or 1.5)))
 				spellPower = spellPower * (castTime / 3.5)
-				
+
 				if( playerCurrentRelic == 22399 ) then
 					healAmount = healAmount + 100
 				elseif( playerCurrentRelic == 28568 ) then
 					healAmount = healAmount + 136
 				end
-				
+
 				if equippedSetCache["Thunderheart"] >= 4 then
 					healModifier = healModifier + 0.05
 				end
-				
+
 			-- Tranquility
 			elseif( spellName == Tranquility ) then
 				spellPower = spellPower * spellData[spellName].coeff * (1 + talentData[EmpoweredRejuv].current)
@@ -1130,7 +1134,7 @@ if( playerClass == "PALADIN" ) then
 
 		CalculateHealing = function(guid, spellID, unit)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(spellData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 
@@ -1191,12 +1195,14 @@ if( playerClass == "PRIEST" ) then
 		local CureDisease = GetSpellInfo(528)
 		local BindingHeal = GetSpellInfo(32546) or "Binding Heal"
 		local EmpoweredHealing = GetSpellInfo(33158) or "Empowered Healing"
-		local Renewal = GetSpellInfo(37563) or "Renewal" -- T4 bonus
+		local Renewal = GetSpellInfo(37563) and "37563" -- T4 bonus
 
 		hotData[Renew] = {coeff = 1, interval = 3, ticks = 5, levels = {8, 14, 20, 26, 32, 38, 44, 50, 56, 60, 65, 70}, averages = {
 			45, 100, 175, 245, 315, 400, 510, 650, 810, 970, 1010, 1110 }}
 		hotData[GreaterHealHot] = hotData[Renew]
-		--hotData[Renewal] = {coeff = 0, interval = 3, ticks = 3, levels = {70}, averages = {150}}
+		if GetLocale() == "enUS" then -- Disable T4 bonus for non english users as it shares the name with Renew
+			hotData[Renewal] = {coeff = 0, interval = 3, ticks = 3, levels = {70}, averages = {150}}
+		end
 
 		spellData[FlashHeal] = {coeff = 1.5 / 3.5, levels = {20, 26, 32, 38, 44, 50, 56, 61, 67}, averages = {
 			{avg(193, 237), avg(194, 239), avg(196, 241), avg(198, 243),  avg(200, 245), avg(202, 247)},
@@ -1271,7 +1277,7 @@ if( playerClass == "PRIEST" ) then
 
 		CalculateHotHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(hotData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(hotData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 			local totalTicks
@@ -1313,7 +1319,7 @@ if( playerClass == "PRIEST" ) then
 		-- If only every other class was as easy as Paladins
 		CalculateHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(spellData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 
@@ -1413,7 +1419,7 @@ if( playerClass == "SHAMAN" ) then
 		-- If only every other class was as easy as Paladins
 		CalculateHealing = function(guid, spellID, unit)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local healAmount = getBaseHealAmount(spellData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
 			local spellPower = GetSpellBonusHealing()
 			local healModifier, spModifier = playerHealModifier, 1
 
@@ -1427,13 +1433,13 @@ if( playerClass == "SHAMAN" ) then
 			-- Chain Heal
 			if( spellName == ChainHeal ) then
 				spellPower = spellPower * spellData[spellName].coeff
-				
+
 				if( equippedSetCache["Skyshatter"] >= 4 ) then
 					healModifier = healModifier * 1.05
 				end
-				
+
 				healModifier = healModifier * (1 + talentData[ImpChainHeal].current)
-				
+
 				if playerCurrentRelic == 28523 then healAmount = healAmount + 87 end
 			-- Heaing Wave
 			elseif( spellName == HealingWave ) then
@@ -1444,9 +1450,9 @@ if( playerClass == "SHAMAN" ) then
 				--healModifier = healModifier * (talentData[HealingWay].spent == 3 and 1.25 or talentData[HealingWay].spent == 2 and 1.16 or talentData[HealingWay].spent == 1 and 1.08 or 1)
 
 				local castTime = spellRank > 3 and 3 or spellRank == 3 and 2.5 or spellRank == 2 and 2 or 1.5
-				
+
 				if playerCurrentRelic == 27544 then spellPower = spellPower + 88 end
-				
+
 				spellPower = spellPower * (castTime / 3.5)
 
 			-- Lesser Healing Wave
@@ -1472,7 +1478,11 @@ if( playerClass == "HUNTER" ) then
 	LoadClassData = function()
 		local MendPet = GetSpellInfo(136)
 
-		spellData[MendPet] = { interval = 1, levels = { 12, 20, 28, 36, 44, 52, 60 }, ticks = 5, averages = {100, 190, 340, 515, 710, 945, 1225 } }
+		if isTBC then
+			hotData[MendPet] = { interval = 3, levels = { 12, 20, 28, 36, 44, 52, 60, 68 }, ticks = 5, averages = {125, 250, 450, 700, 1000, 1400, 1825, 2375 } }
+		else
+			spellData[MendPet] = { interval = 1, levels = { 12, 20, 28, 36, 44, 52, 60 }, ticks = 5, averages = {100, 190, 340, 515, 710, 945, 1225 } }
+		end
 
 		itemSetsData["Giantstalker"] = {16851, 16849, 16850, 16845, 16848, 16852, 16846, 16847}
 
@@ -1480,13 +1490,22 @@ if( playerClass == "HUNTER" ) then
 			return compressGUID[UnitGUID("pet")], healAmount
 		end
 
-		CalculateHealing = function(guid, spellID)
+		CalculateHotHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local amount = getBaseHealAmount(spellData, spellName, spellRank)
+			local amount = getBaseHealAmount(hotData, spellName, spellRank)
 
 			if( equippedSetCache["Giantstalker"] >= 3 ) then amount = amount * 1.1 end
 
-			return CHANNEL_HEALS, ceil(amount / spellData[spellName].ticks), spellData[spellName].ticks, spellData[spellName].interval
+			return HOT_HEALS, ceil(amount / hotData[spellName].ticks), hotData[spellName].ticks, hotData[spellName].interval
+		end
+
+		CalculateHealing = function(guid, spellID)
+			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
+
+			if( equippedSetCache["Giantstalker"] >= 3 ) then healAmount = healAmount * 1.1 end
+
+			return CHANNEL_HEALS, ceil(healAmount / spellData[spellName].ticks), spellData[spellName].ticks, spellData[spellName].interval
 		end
 	end
 end
@@ -1497,7 +1516,7 @@ if( playerClass == "WARLOCK" ) then
 		local DrainLife = GetSpellInfo(689)
 		local ImpHealthFunnel = GetSpellInfo(18703)
 
-		spellData[HealthFunnel] = { interval = 1, levels = { 12, 20, 28, 36, 44, 52, 60, 68 }, ticks = 10, averages = { 0, 0 ,0, 0, 0, 0, 0, 0, 0 } }
+		spellData[HealthFunnel] = { interval = 1, levels = { 12, 20, 28, 36, 44, 52, 60, 68 }, ticks = 10, averages = { 120, 240, 430, 640, 890, 1190, 1530, 1880 } }
 		spellData[DrainLife] = { interval = 1, levels = { 14, 22, 30, 38, 46, 54, 62, 69 }, ticks = 5, averages = { 10 * 5, 17 * 5, 29 * 5, 41 * 5, 55 * 5, 71 * 5, 87 * 5, 108 * 5 } }
 
 		talentData[ImpHealthFunnel] = { mod = 0.1, current = 0 }
@@ -1508,11 +1527,11 @@ if( playerClass == "WARLOCK" ) then
 
 		CalculateHealing = function(guid, spellID)
 			local spellName, spellRank = GetSpellInfo(spellID), SpellIDToRank[spellID]
-			local amount = getBaseHealAmount(spellData, spellName, spellRank)
+			local healAmount = getBaseHealAmount(spellData, spellName, spellID, spellRank)
 
-			amount = amount * (1 + talentData[ImpHealthFunnel].current)
+			healAmount = healAmount * (1 + talentData[ImpHealthFunnel].current)
 
-			return CHANNEL_HEALS, ceil(amount / spellData[spellName].ticks), spellData[spellName].ticks, spellData[spellName].interval
+			return CHANNEL_HEALS, ceil(healAmount / spellData[spellName].ticks), spellData[spellName].ticks, spellData[spellName].interval
 		end
 	end
 end
@@ -1597,6 +1616,7 @@ HealComm.healingModifiers = HealComm.healingModifiers or {
 	[28440] = 0.25, -- Veil of Shadow
 	[13583] = 0.50, -- Curse of the Deadwood
 	[23230] = 0.50, -- Blood Fury
+	[31977] = 1.50, -- Curse of Infinity
 }
 
 HealComm.healingStackMods = HealComm.healingStackMods or {
@@ -1986,21 +2006,21 @@ end
 local function parseHotBomb(casterGUID, wasUpdated, spellID, amount, ...)
 	local spellName, spellRank = GetSpellInfo(spellID)
 	if( not amount or not spellName or select("#", ...) == 0 ) then return end
-	
+
 	-- If we don't have a pending hot then there is no bomb as far as were concerned
 	local hotPending = pendingHots[casterGUID] and pendingHots[casterGUID][spellName]
 	if( not hotPending or not hotPending.bitType ) then return end
 	hotPending.hasBomb = true
-	
+
 	pendingHeals[casterGUID] = pendingHeals[casterGUID] or {}
 	pendingHeals[casterGUID][spellName] = pendingHeals[casterGUID][spellName] or {}
-	
+
 	local pending = pendingHeals[casterGUID][spellName]
 	pending.endTime = hotPending.endTime
 	pending.spellID = spellID
 	pending.bitType = BOMB_HEALS
 	pending.stack = 1 -- TBC Lifebloom bomb heal does not stack
-	
+
 	loadHealList(pending, amount, pending.stack, pending.endTime, nil, ...)
 
 	if( not wasUpdated ) then
@@ -2266,7 +2286,7 @@ function HealComm:COMBAT_LOG_EVENT_UNFILTERED(...)
 				local targets, amt = GetHealTargets(type, destGUID, max(amount, 0), spellID)
 				if targets then
 					parseHotHeal(sourceGUID, false, spellID, amt, totalTicks, tickInterval, strsplit(",", targets))
-					
+
 					-- Hot with a bomb!
 					if( bombAmount ) then
 						local bombTargets, bombAmount = GetHealTargets(BOMB_HEALS, destGUID, math.max(bombAmount, 0), spellName)
@@ -2303,19 +2323,19 @@ function HealComm:COMBAT_LOG_EVENT_UNFILTERED(...)
 			local amount = getRecord(pending, destGUID)
 			if( amount ) then
 				parseHotHeal(sourceGUID, true, spellID, amount, pending.totalTicks, pending.tickInterval, compressGUID[destGUID])
-				
+
 				-- Plant the bomb
 				local bombPending = pending.hasBomb and pendingHeals[sourceGUID][spellName]
 				if( bombPending and bombPending.bitType ) then
 					local bombAmount = getRecord(bombPending, destGUID)
 					if( bombAmount ) then
 						parseHotBomb(sourceGUID, true, spellID, bombAmount, compressGUID[destGUID])
-						
+
 						sendMessage(string.format("UB:%s:%d:%d:%s:%d:%d:%s", pending.totalTicks, spellID, bombAmount, compressGUID[destGUID], amount, pending.tickInterval, compressGUID[destGUID]))
 						return
 					end
 				end
-				
+
 				sendMessage(string.format("U:%s:%d:%d:%d:%s", spellID, amount, pending.totalTicks, pending.tickInterval, compressGUID[destGUID]))
 			end
 		end

--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -398,7 +398,7 @@ function HealComm:GetGUIDUnitMapTable()
 end
 
 
--- Custom function for HealBarsClassic that returns heals within a timeframe
+-- Get heal amount using the passed filters (supports custom start time)
 function HealComm:GetTimeframeHealAmount(guid, bitFlag, startTime, time, ignoreGUID,srcGUID)
 
 	local healFrom,healTime


### PR DESCRIPTION
New function allows for getting heals within a specified timeframe (start time, end time)
Gift of the Naaru support
Tranquility now properly applies to all nearby party members
Fixed heals getting stuck on. If a heal success occurs before a heal cancel, the next heal would become stuck on if cancelled. 
Fixed AoE heals targeting dead players