### PR TITLE
Avoid nil assignment error on Classic Era

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -1143,7 +1143,10 @@ if( playerClass == "PRIEST" ) then
 		hotData[Renew] = {coeff = 1, interval = 3, ticks = 5, levels = {8, 14, 20, 26, 32, 38, 44, 50, 56, 60, 65, 70}, averages = {
 			45, 100, 175, 245, 315, 400, 510, 650, 810, 970, 1010, 1110 }}
 		hotData[GreaterHealHot] = hotData[Renew]
-		hotData[Renewal] = {coeff = 0, interval = 3, ticks = 3, levels = {70}, averages = {150}}
+		
+		if Renewal then
+			hotData[Renewal] = {coeff = 0, interval = 3, ticks = 3, levels = {70}, averages = {150}}
+		end
 
 		spellData[FlashHeal] = {coeff = 1.5 / 3.5, levels = {20, 26, 32, 38, 44, 50, 56, 61, 67}, averages = {
 			{avg(193, 237), avg(194, 239), avg(196, 241), avg(198, 243),  avg(200, 245), avg(202, 247)},


### PR DESCRIPTION
I was rebasing VuhDo for Classic Era 1.14.0 and discovered the fixes to make 'Renewal' work for BCC introduced this regression.

Please merge into the upstream official LibHealComm-4.0 repo on CurseForge.

Thanks!