### PR TITLE
Prevent stuck heal prediction when prematurely stopping Penance channel

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -2922,6 +2922,18 @@ function HealComm:UNIT_SPELLCAST_STOP(unit, castGUID, spellID)
 	spellCastSucceeded[spellID] = nil
 end
 
+function HealComm:UNIT_SPELLCAST_CHANNEL_STOP(unit, _, spellID)
+	-- Also end heal if a Penance cast is stopped prematurely (e.g. by movement)
+	if( unit ~= "player" ) then return end
+
+	if not spellCastSucceeded[spellID] then
+		parseHealEnd(playerGUID, nil, "name", spellID, true)
+		sendMessage(format("S::%d:1", spellID or 0))
+	end
+
+	spellCastSucceeded[spellID] = nil
+end
+
 -- Cast didn't go through, recheck any charge data if necessary
 function HealComm:UNIT_SPELLCAST_INTERRUPTED(unit, castGUID, spellID)
 	local spellName = GetSpellInfo(spellID)
@@ -3305,6 +3317,7 @@ function HealComm:OnInitialize()
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_START")
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_DELAYED")
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
 	self.eventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")

--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -2923,15 +2923,14 @@ function HealComm:UNIT_SPELLCAST_STOP(unit, castGUID, spellID)
 end
 
 function HealComm:UNIT_SPELLCAST_CHANNEL_STOP(unit, _, spellID)
-	-- Also end heal if a Penance cast is stopped prematurely (e.g. by movement)
-	if( unit ~= "player" ) then return end
+	local spellName = GetSpellInfo(spellID)
+	if( unit ~= "player" or not spellData[spellName] ) then return end
 
-	if not spellCastSucceeded[spellID] then
+	-- End heal if a Penance cast is stopped prematurely (e.g. by movement)
+	if( spellName == "Penance" ) then
 		parseHealEnd(playerGUID, nil, "name", spellID, true)
 		sendMessage(format("S::%d:1", spellID or 0))
 	end
-
-	spellCastSucceeded[spellID] = nil
 end
 
 -- Cast didn't go through, recheck any charge data if necessary


### PR DESCRIPTION
This PR fixes an issue with the priest ability Penance. As Penance is a channeled heal with 3 ticks, it can be prematurely stopped (by e.g. moving) thereby healing less than the originally predicted amount. Up until now, this lead to the heal prediction becoming stuck, as the remaining ticks never happened.

The solution is to simply listen for SPELLCAST_CHANNEL_STOP events and then send the necessary messages.