### PR TITLE
COMBAT_LOG_EVENT_UNFILTERED handling

### DIFF
--- a/LibHealComm-4.0.lua
+++ b/LibHealComm-4.0.lua
@@ -2680,6 +2680,9 @@ function HealComm:COMBAT_LOG_EVENT_UNFILTERED(...)
 
 	local _, spellName = select(12, ...)
 	local destUnit = guidToUnit[destGUID]
+	
+	if not destUnit then return end -- We only handle own group units
+	
 	local spellID = destUnit and select(10, unitHasAura(destUnit, spellName)) or select(7, GetSpellInfo(spellName))
 
 	-- Heal or hot ticked that the library is tracking


### PR DESCRIPTION
Prevent COMBAT_LOG_EVENT_UNFILTERED handling for units not in group.

This fixes a lua error with Eartliving (Shaman) proccing on units not in group and should improve performance. See https://github.com/Aviana/LunaUnitFrames/issues/960